### PR TITLE
[update]トップページの修正

### DIFF
--- a/book/intro.md
+++ b/book/intro.md
@@ -1,2 +1,30 @@
-# はじめに
-xxx
+# 峰野研究室 公開教材・研究関連リソース
+## はじめに
+　本リポジトリでは，[静岡大学情報学部情報科学科 峰野研究室](https://wwp.shizuoka.ac.jp/minelab/)が作成・提供する教育・研究関連コンテンツを公開しています．学部3年次科目「情報科学演習」の教材をはじめ，興味のある学外の方にも自習用として活用いただけるよう，地域社会への貢献の一環として一般公開しています．
+
+## 情報科学演習
+### **画像認識パート**
+- [**概要**](https://minenolab.github.io/CS-Exercise/part2_image/intro.html)
+
+1. [**作業サーバーセットアップ**](https://minenolab.github.io/CS-Exercise/part2_image/notebooks/01_setup.html)
+2. [**画像処理**](https://minenolab.github.io/CS-Exercise/part2_image/notebooks/02_image_processing.html)
+3. [**機械学習**](https://minenolab.github.io/CS-Exercise/part2_image/notebooks/03_machine_learning.html)
+
+- [**まとめ**](https://minenolab.github.io/CS-Exercise/part2_image/summary.html)
+### **時系列予測パート**
+- [**概要**](https://minenolab.github.io/CS-Exercise/part3_timeseries/intro.html#id4)
+
+1. [**Pandasの基礎**](https://minenolab.github.io/CS-Exercise/part3_timeseries/notebooks/01_pandas_basics.html)
+2. [**データ可視化の基礎**](https://minenolab.github.io/CS-Exercise/part3_timeseries/notebooks/02_visualization_basics.html)
+3. [**特徴量エンジニアリング**](https://minenolab.github.io/CS-Exercise/part3_timeseries/notebooks/03_time_series_features.html)
+4. [**予測モデルの構築**](https://minenolab.github.io/CS-Exercise/part3_timeseries/notebooks/04_prediction_model.html)
+### IoTパート
+- [**概要**](https://minenolab.github.io/CS-Exercise/part4_iot/intro.html#)
+
+1. [**RaspberryPiセットアップ**](https://minenolab.github.io/CS-Exercise/part4_iot/notebooks/01_raspi_setup.html)
+2. [**PiNodeセットアップ**](https://minenolab.github.io/CS-Exercise/part4_iot/notebooks/02_pinode_setup.html)
+3. [**Spresenseセットアップ**](https://minenolab.github.io/CS-Exercise/part4_iot/notebooks/03_spresense_setup.html)
+4. [**現場作業注意事項**](https://minenolab.github.io/CS-Exercise/part4_iot/04_iot_physical_install.html)
+
+## その他教育・研究関連コンテンツ
+順次公開予定


### PR DESCRIPTION
book/intro.mdを修正．
情報科学演習の教材に加え，将来的に謝金の納品物なども「その他教育・研究関連コンテンツ」として掲載できるようページ攻勢を整備した．